### PR TITLE
squid:SwitchLastCaseIsDefaultCheck - switch statements should end wit…

### DIFF
--- a/src/main/java/imagenet/CNNImageNetMain.java
+++ b/src/main/java/imagenet/CNNImageNetMain.java
@@ -137,6 +137,8 @@ public class CNNImageNetMain {
             case "SparkCluster":
                 new CNNImageNetSparkExample().initialize();
                 break;
+            default:
+                break;
         }
         System.out.println("****************Example finished********************");
     }
@@ -192,6 +194,8 @@ public class CNNImageNetMain {
                         paramPaths = NetSaverLoaderUtils.getStringParamPaths(outputPath, layerIdsVGG);
                         NetSaverLoaderUtils.loadParameters(model, layerIdsVGG, paramPaths);
                     }
+                    break;
+                default:
                     break;
             }
         }

--- a/src/main/java/imagenet/Utils/ImageNetLoader.java
+++ b/src/main/java/imagenet/Utils/ImageNetLoader.java
@@ -69,6 +69,8 @@ public class ImageNetLoader extends BaseImageLoader implements Serializable{
                 throw new NotImplementedException("Detection has not been setup yet");
             case "DET_VAL":
                 throw new NotImplementedException("Detection has not been setup yet");
+            default:
+                break;
         }
     }
 
@@ -112,6 +114,8 @@ public class ImageNetLoader extends BaseImageLoader implements Serializable{
                 throw new NotImplementedException("Detection has not been setup yet");
             case "DET_VAL":
                 throw new NotImplementedException("Detection has not been setup yet");
+            default:
+                break;
         }
     }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:SwitchLastCaseIsDefaultCheck - switch statements should end with a default clause

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:SwitchLastCaseIsDefaultCheck

Please let me know if you have any questions.

M-Ezzat